### PR TITLE
Fixing the process of passing and saving journal id and emotions

### DIFF
--- a/screens/Analysis.jsx
+++ b/screens/Analysis.jsx
@@ -112,7 +112,7 @@ export default function Analysis() {
   };
 
   const entry = route.params || ENTRY_DEFAULTS;
-  const { entryId, entryTitle, entryText, journalDate, type } = entry;
+  const { id: entryId, entryTitle, entryText, journalDate, type } = entry;
 
   const [topEmotions, setTopEmotions] = useState([]);
   const [loadingEmotions, setLoadingEmotions] = useState(true);

--- a/screens/EditJournalEntryModal.js
+++ b/screens/EditJournalEntryModal.js
@@ -44,7 +44,7 @@ const EditJournalEntryModal = ({
     };
 
     try {
-      await onSave(updatedEntry, setJournalEntries);
+      await onSave(updatedEntry.id, updatedEntry);
       onClose();
     } catch (error) {
       console.error("Error saving changes:", error.message);

--- a/screens/HomePage.jsx
+++ b/screens/HomePage.jsx
@@ -33,7 +33,7 @@ import {
   getJournalEntries,
   handleSavePromptEntry,
   deleteJournalEntry,
-  updateEntryInFirestore,
+  updateJournalEntry,
 } from "../functions/JournalFunctions";
 import prompts from "../assets/prompts";
 import quotes from "../assets/Quotes";
@@ -430,7 +430,7 @@ const handleSaveEntry = async () => {
             setEditModalVisible(false);
             navigation.navigate("Analysis", { ...selectedEntry });
           }}
-          onSave={updateEntryInFirestore} // Correctly pass the onSave function here
+          onSave={updateJournalEntry} // Correctly pass the onSave function here
           setJournalEntries={setJournalEntries} // Pass the state updater
         />
       )}


### PR DESCRIPTION
Basically there were a couple of issues with the save function: it passed stuff to updateEntryInFirestore (a function that was renamed to UpdateJournalEntry a few days ago), and it passed stuff according to the old schema which had a different method of storing ids and didn't store top emotions. This is now fixed.