### PR TITLE
Fix Calendar, Analysis Response Error and Analysis Entry ID Not Found

### DIFF
--- a/screens/Analysis.jsx
+++ b/screens/Analysis.jsx
@@ -112,7 +112,7 @@ export default function Analysis() {
   };
 
   const entry = route.params || ENTRY_DEFAULTS;
-  const { id: entryId, entryTitle, entryText, journalDate, type } = entry;
+  const { entryId, entryTitle, entryText, journalDate, type } = entry;
 
   const [topEmotions, setTopEmotions] = useState([]);
   const [loadingEmotions, setLoadingEmotions] = useState(true);
@@ -183,7 +183,7 @@ useEffect(() => {
       if (!detectedEmotions || !Array.isArray(detectedEmotions)) {
         throw new Error("Invalid response from emotion analysis API.");
       }
-
+      console.log(entry)
       await parseTopEmotions(detectedEmotions);
     } catch (error) {
       console.error("Error fetching emotions:", error.message || error);

--- a/screens/Analysis.jsx
+++ b/screens/Analysis.jsx
@@ -183,7 +183,6 @@ useEffect(() => {
       if (!detectedEmotions || !Array.isArray(detectedEmotions)) {
         throw new Error("Invalid response from emotion analysis API.");
       }
-      console.log(entry)
       await parseTopEmotions(detectedEmotions);
     } catch (error) {
       console.error("Error fetching emotions:", error.message || error);

--- a/screens/Analysis.jsx
+++ b/screens/Analysis.jsx
@@ -166,7 +166,7 @@ useEffect(() => {
         setTopEmotions(entry.topEmotions);
         return;
       }
-      if (type === "prompts") {
+      if (type === "prompts" && Array.isArray(entryText)) {
         // Combine all prompt responses into a single string
         textForAnalysis = entryText
           .map((item) => item.response)

--- a/screens/HomePage.jsx
+++ b/screens/HomePage.jsx
@@ -284,19 +284,16 @@ const HomePage = () => {
   if (route.params?.viewJournalEntry) {
     handleOpenJournal(route.params.viewJournalEntry)
     navigation.setParams({ viewJournalEntry: null }); // Clear params
-  }
-
-    // Check for creating a new entry date
-if (route.params?.selectedDate) {
+  }else if (route.params?.selectedDate) {
   console.log("Creating entry for date:", route.params.selectedDate);
   setNewEntryDate(route.params.selectedDate); // Set the selected date for the new entry
   setCreateEntryModalVisible(true); // Open the modal for creating an entry
   console.log("Modal visibility set to true");
   navigation.setParams({ selectedDate: null }); // Clear params
-}
-
+  }else {
     // Fetch existing journal entries for the authenticated user
     fetchEntries();
+  }
 
     // Cleanup the authentication listener on component unmount
     return () => {


### PR DESCRIPTION
- calendar was bugging out due to `fetchEntries` called and updating components even after the modal was supposed to be visible
- analysis page was handling all `prompt` types as arrays, whereas some prompt responses have been concatenated to send to `HuggingFace`
- analysis page used `id` from entries but the schema has been updated to store `id` as `entryId`